### PR TITLE
feat: send connection requests with AI-generated personalized notes

### DIFF
--- a/linkedin/actions/connect.py
+++ b/linkedin/actions/connect.py
@@ -2,9 +2,10 @@
 import logging
 from typing import Dict, Any
 
+from playwright.sync_api import Error as PlaywrightError
 from linkedin.enums import ProfileState
 from linkedin.exceptions import SkipProfile, ReachedConnectionLimit
-from linkedin.browser.nav import find_top_card, dump_page_html
+from linkedin.browser.nav import find_top_card, dump_page_html, human_type
 
 logger = logging.getLogger(__name__)
 
@@ -30,32 +31,126 @@ SELECTORS = {
         'li:text-is("Connect"), '
         'span[role="button"]:text-is("Connect")'
     ),
-    "send_now": 'button:has-text("Send now"), button[aria-label*="Send without"], button[aria-label*="Send invitation"]',
+    # Note flow selectors — LinkedIn A/B tests these, so each is a fallback chain
+    "add_note_button": (
+        'button[aria-label*="Add a note"]:visible, '
+        'button:has-text("Add a note"):visible'
+    ),
+    "note_textarea": (
+        'textarea[name="message"]:visible, '
+        'textarea[placeholder*="note"i]:visible, '
+        'textarea[maxlength="300"]:visible, '
+        'textarea:visible'
+    ),
+    "send_with_note": (
+        'button[aria-label*="Send invitation"]:visible, '
+        'button[aria-label*="Send now"]:visible, '
+        'button:has-text("Send"):visible'
+    ),
+    "send_now": (
+        'button:has-text("Send now"), '
+        'button[aria-label*="Send without"], '
+        'button[aria-label*="Send invitation"]'
+    ),
 }
+
+NOTE_MAX_CHARS = 295  # LinkedIn hard limit is 300; keep a small buffer
+
+
+def generate_connection_note(session, profile: Dict[str, Any]) -> str | None:
+    """Generate a personalized connection note via LLM. Returns None on any failure."""
+    try:
+        from langchain_openai import ChatOpenAI
+        from linkedin.conf import get_llm_config
+
+        llm_api_key, ai_model, llm_api_base = get_llm_config()
+        if not llm_api_key:
+            return None
+
+        first_name = profile.get("first_name", "")
+        last_name = profile.get("last_name", "")
+        headline = profile.get("headline", "")
+        summary = (profile.get("summary") or "")[:300]
+
+        # Need at least a headline or name to write a specific note
+        if not headline and not first_name:
+            return None
+
+        campaign = session.campaign
+        product_docs = (getattr(campaign, "product_docs", "") or "")[:400]
+        campaign_objective = (getattr(campaign, "campaign_objective", "") or "")[:300]
+
+        profile_info = f"Name: {first_name} {last_name}".strip()
+        if headline:
+            profile_info += f"\nHeadline: {headline}"
+        if summary:
+            profile_info += f"\nSummary: {summary}"
+
+        system_prompt = (
+            "You write LinkedIn connection request notes. Write one short, genuine note.\n\n"
+            "Rules:\n"
+            "- Under 280 characters. This is a hard limit.\n"
+            "- Reference something specific from their profile: their role, company, or what they are working on.\n"
+            "- Sound like a real person who noticed their work, not a bot.\n"
+            "- No sales pitch. No mention of job seeking. No generic openers like 'I would love to connect'.\n"
+            "- No em dashes, no exclamation points, no emoji.\n"
+            "- First person, conversational, specific.\n"
+            "- Do NOT start with Hi, Hello, or their name.\n"
+            "- Return ONLY the note text. No quotes, no explanation.\n\n"
+            f"About me (context only, do not repeat this):\n{product_docs}\n\n"
+            f"Outreach objective:\n{campaign_objective}"
+        )
+
+        user_prompt = f"Write a connection note for:\n\n{profile_info}"
+
+        llm = ChatOpenAI(
+            model=ai_model,
+            temperature=0.9,
+            api_key=llm_api_key,
+            base_url=llm_api_base,
+            timeout=30,
+        )
+        response = llm.invoke([
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ])
+
+        note = response.content.strip().strip('"\'')
+        if len(note) > NOTE_MAX_CHARS:
+            note = note[:NOTE_MAX_CHARS - 3] + "..."
+
+        if not note:
+            return None
+
+        logger.info("Generated connection note (%d chars): %s", len(note), note)
+        return note
+
+    except Exception as exc:
+        logger.warning("Note generation failed, falling back to no-note: %s", exc)
+        return None
 
 
 def send_connection_request(
         session: "AccountSession",
         profile: Dict[str, Any],
 ) -> ProfileState:
-    """
-    Sends a LinkedIn connection request WITHOUT a note (fastest & safest).
+    """Send a LinkedIn connection request, with a personalized note when possible."""
+    public_identifier = profile.get("public_identifier")
 
-    Assumes the profile page is already loaded (caller navigates via
-    ``get_connection_status`` or ``visit_profile`` beforehand).
-    """
-    public_identifier = profile.get('public_identifier')
-
-    # Send invitation WITHOUT note (current active flow)
     if not _connect_direct(session) and not _connect_via_more(session):
-        logger.debug("Connect button not found for %s — staying at current stage", public_identifier)
+        logger.debug("Connect button not found for %s", public_identifier)
         dump_page_html(session, profile)
         return ProfileState.QUALIFIED
 
-    _click_without_note(session)
-    _check_weekly_invitation_limit(session)
+    # Try to send with a personalized note; fall back to no-note silently
+    note = generate_connection_note(session, profile)
+    if note and _click_with_note(session, note):
+        logger.debug("Connection request with note submitted for %s", public_identifier)
+    else:
+        _click_without_note(session)
+        logger.debug("Connection request without note submitted for %s", public_identifier)
 
-    logger.debug("Connection request submitted for %s", public_identifier)
+    _check_weekly_invitation_limit(session)
     return ProfileState.PENDING
 
 
@@ -87,10 +182,8 @@ def _connect_via_more(session):
     top_card = find_top_card(session)
     page = session.page
 
-    # Dropdown may render as a portal outside top_card, so search page-wide
     connect_option = page.locator(SELECTORS["connect_option"])
 
-    # Connect option may already be visible (More dropdown opened by status check)
     if connect_option.count() == 0:
         more = top_card.locator(SELECTORS["more_button"])
         if more.count() == 0:
@@ -102,16 +195,55 @@ def _connect_via_more(session):
     if connect_option.count() == 0:
         return False
     connect_option.first.click()
-    logger.debug("Used 'More → Connect' flow")
+    logger.debug("Used 'More -> Connect' flow")
+    return True
 
+
+def _click_with_note(session, note: str) -> bool:
+    """Open 'Add a note', type the note with human delays, then send.
+
+    Returns True if the full flow completed, False if any step failed
+    (caller falls back to no-note in that case).
+    """
+    page = session.page
+    session.wait()
+
+    add_note_btn = page.locator(SELECTORS["add_note_button"])
+    try:
+        add_note_btn.first.wait_for(state="visible", timeout=5000)
+    except (PlaywrightError, Exception):
+        logger.debug("'Add a note' button not visible — falling back to no-note")
+        return False
+
+    add_note_btn.first.click()
+    session.wait()
+
+    textarea = page.locator(SELECTORS["note_textarea"])
+    try:
+        textarea.first.wait_for(state="visible", timeout=5000)
+    except (PlaywrightError, Exception):
+        logger.debug("Note textarea not visible — falling back to no-note")
+        return False
+
+    # Human-like typing with randomized per-keystroke delay
+    human_type(textarea.first, note)
+    session.wait()
+
+    send_btn = page.locator(SELECTORS["send_with_note"])
+    try:
+        send_btn.first.wait_for(state="visible", timeout=5000)
+    except (PlaywrightError, Exception):
+        logger.debug("Send button not visible after note — falling back to no-note")
+        return False
+
+    send_btn.first.click(force=True)
+    session.wait()
     return True
 
 
 def _click_without_note(session):
-    """Click flow: sends connection request instantly without note."""
+    """Click 'Send now' / 'Send without a note' — no note flow."""
     session.wait()
-
-    # Click "Send now" / "Send without a note"
     send_btn = session.page.locator(SELECTORS["send_now"])
     send_btn.first.click(force=True)
     session.wait()
@@ -132,13 +264,12 @@ if __name__ == "__main__":
         "public_identifier": args.profile,
     }
 
-    logger.info("Testing connection request as %s → %s", session, args.profile)
-
+    logger.info("Testing connection request as %s -> %s", session, args.profile)
     connection_status = get_connection_status(session, test_profile)
-    logger.info("Pre-check status → %s", connection_status.value)
+    logger.info("Pre-check status -> %s", connection_status.value)
 
     if connection_status in (ProfileState.CONNECTED, ProfileState.PENDING):
         logger.info("Skipping – already %s", connection_status.value)
     else:
         status = send_connection_request(session=session, profile=test_profile)
-        logger.info("Finished → Status: %s", status.value)
+        logger.info("Finished -> Status: %s", status.value)


### PR DESCRIPTION
Closes #803

## Summary

Connection requests are currently hardcoded to send without a note. This PR adds LLM-powered personalized note generation to the connect flow.

- Generates a note under 295 chars using the campaign's `product_docs` and `campaign_objective` as context
- Uses `temperature=0.9` so each note is unique (identical notes across sends is a LinkedIn bot signal)
- Falls back to the existing no-note flow silently on any failure (LLM timeout, missing profile data, UI selector mismatch)
- Uses the existing `human_type` utility for natural per-keystroke typing delays

## Changes

**`linkedin/actions/connect.py`**
- `generate_connection_note(session, profile)` — LLM call with 30s timeout, returns `None` on any failure
- `_click_with_note(session, note)` — Playwright flow: Add a note → human_type → Send, with per-step 5s timeouts
- Added `add_note_button`, `note_textarea`, `send_with_note` selector chains (fallback chains because LinkedIn A/B tests UI variants per account)
- `send_connection_request()` — tries note flow first, falls back to `_click_without_note()` if anything fails

## Safety

- Hard 295-char truncation before sending
- Every Playwright step in try/except — a broken selector never crashes the daemon
- LLM errors are caught and logged as warnings, not raised
- No changes to rate limits, timing, or anti-detection behavior

## Test Plan

- [ ] Verified imports cleanly (`python -c "from linkedin.actions.connect import send_connection_request"`)
- [ ] Ran against a real LinkedIn account — notes generated and sent correctly
- [ ] Tested fallback path by temporarily returning `None` from `generate_connection_note`