### PR TITLE
feat: optional signed receipt-on-send (sender ToS attestation)

### DIFF
--- a/openoutreach/trust_gate.py
+++ b/openoutreach/trust_gate.py
@@ -1,0 +1,95 @@
+"""trust_gate.py -- optional, tamper-evident receipt-on-send for outreach actions.
+
+Every automated outreach carries a platform-ToS question: was this rate-limited, human-reviewed,
+and not scraped? This mints a signed receipt at send time capturing the sender's attestation of
+exactly that, plus a hash of the message. It records a sender attestation and binds it to the
+message, verifiable from the certificate alone -- it is NOT a proof that the platform's ToS were
+actually met, only tamper-evident evidence of what the sender attested and when.
+
+OPTIONAL by design: the cryptography lives in the open-source `openagentontology` package
+(Apache-2.0), imported lazily. If the package is absent, this returns an explicit unsigned stub
+(never a fake signature), so adding this module imposes no new required dependency. A broken
+install (not mere absence) is surfaced, not swallowed.
+
+    pip install "openagentontology[pq]"   # Ed25519 + ML-DSA-65 + SLH-DSA legs
+
+Usage:
+    from openoutreach.trust_gate import mint_send_receipt, verify_receipt
+    receipt = mint_send_receipt(
+        recipient_ref="prospect-9f2a",
+        message="Hi -- saw your post on agent governance, 15 min?",
+        rate_limited=True, human_reviewed=True, scraped=False,
+    )
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from typing import Any, Dict
+
+
+def _oao():
+    """Return the openagentontology.receipt module, or None ONLY when the package is genuinely
+    absent. Absence is checked with find_spec first; if the package is present but its import
+    fails (a broken install), that error propagates so it is surfaced, not swallowed as
+    'unsigned'."""
+    if importlib.util.find_spec("openagentontology") is None:
+        return None
+    from openagentontology import receipt as _r  # type: ignore  # broken install raises here
+    return _r
+
+
+def _hash(s: str) -> str:
+    """Full SHA-256 integrity hash. Tamper-evidence, not a privacy guarantee (low-entropy
+    inputs can be brute-forced); do not treat it as redaction."""
+    return "sha256:" + hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def build_send_manifest(recipient_ref: str, message: str, *, rate_limited: bool,
+                        human_reviewed: bool, scraped: bool) -> Dict[str, Any]:
+    """Assemble the ASCII-safe action manifest for one outreach send."""
+    recipient_ref = str(recipient_ref).strip()
+    if not recipient_ref:
+        raise ValueError("recipient_ref must be a non-empty pseudonymous reference")
+    return {
+        "operation": "outreach_send",
+        "recipient_ref": recipient_ref,          # pseudonymous, minimized (may still identify)
+        "message_hash": _hash(message or ""),
+        "tos_attestation": {
+            "rate_limited": bool(rate_limited),
+            "human_reviewed": bool(human_reviewed),
+            "scraped": bool(scraped),
+        },
+        "policy": "sender ToS self-attestation",
+    }
+
+
+def mint_send_receipt(recipient_ref: str, message: str, *, rate_limited: bool = False,
+                      human_reviewed: bool = False, scraped: bool = False) -> Dict[str, Any]:
+    """Mint a (post-quantum, when available) receipt over one outreach send.
+
+    Returns the receipt dict. If `openagentontology` is not installed, returns an explicit
+    unsigned stub flagged `signed: False` -- the attestation is still hashed and carried, but
+    honestly marked as not cryptographically signed.
+    """
+    manifest = build_send_manifest(
+        recipient_ref, message,
+        rate_limited=rate_limited, human_reviewed=human_reviewed, scraped=scraped)
+    oao = _oao()
+    if oao is None:
+        return {
+            "type": "AgentGovernanceReceipt",
+            "decision": "OUTREACH_SENT",
+            "evidence": {"ontology": manifest},
+            "signed": False,
+            "unsigned_reason": "install 'openagentontology[pq]' to sign this receipt",
+        }
+    return oao.mint_receipt(manifest, decision="OUTREACH_SENT")
+
+
+def verify_receipt(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    """Verify a send receipt from the cert alone. Requires openagentontology to check sigs."""
+    oao = _oao()
+    if oao is None:
+        return {"ok": False, "reason": "install 'openagentontology' to verify signatures"}
+    return oao.verify_receipt(receipt)

--- a/tests/test_trust_gate.py
+++ b/tests/test_trust_gate.py
@@ -1,0 +1,49 @@
+"""test_trust_gate.py -- optional receipt-on-send mints + verifies (or degrades honestly)."""
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from openoutreach.trust_gate import (
+    build_send_manifest,
+    mint_send_receipt,
+    verify_receipt,
+    _oao,
+)
+
+_HAS_OAO = _oao() is not None
+
+
+def test_requires_recipient_ref():
+    with pytest.raises(ValueError):
+        build_send_manifest("", "hi", rate_limited=True, human_reviewed=True, scraped=False)
+
+
+def test_message_is_hashed_not_stored():
+    m = build_send_manifest("p-1", "secret pitch text", rate_limited=True,
+                            human_reviewed=True, scraped=False)
+    assert m["message_hash"].startswith("sha256:") and len(m["message_hash"]) == 71
+    assert "secret pitch text" not in str(m)
+
+
+def test_unsigned_stub_when_absent(monkeypatch):
+    monkeypatch.setattr("openoutreach.trust_gate._oao", lambda: None)
+    r = mint_send_receipt("p-1", "hi", rate_limited=True, human_reviewed=True)
+    assert r["signed"] is False and "signature_b64" not in r
+
+
+@pytest.mark.skipif(not _HAS_OAO, reason="openagentontology not installed")
+def test_real_receipt_mints_and_verifies():
+    r = mint_send_receipt("prospect-9f2a", "Hi, 15 min?", rate_limited=True, human_reviewed=True)
+    assert verify_receipt(r)["ok"] is True
+    assert r["evidence"]["ontology"]["tos_attestation"]["rate_limited"] is True
+
+
+@pytest.mark.skipif(not _HAS_OAO, reason="openagentontology not installed")
+def test_tamper_on_attestation_breaks_verification():
+    r = mint_send_receipt("prospect-9f2a", "Hi, 15 min?", rate_limited=True, human_reviewed=True)
+    t = copy.deepcopy(r)
+    # an operator flips "scraped" to hide a violation after signing
+    t["evidence"]["ontology"]["tos_attestation"]["scraped"] = True
+    assert verify_receipt(t)["ok"] is False


### PR DESCRIPTION
## What

An **optional** module (`openoutreach/trust_gate.py`) that, at send time, mints a tamper-evident receipt of the sender's ToS attestation (rate-limited / human-reviewed / not-scraped) bound to a hash of the message. An operator can later show, from the certificate alone, what was attested and that it was not edited.

## Honest scope

This records a **sender self-attestation**; it is not a proof that the platform's ToS were met. PII is minimized (pseudonymous recipient ref + message hash), not eliminated. The crypto is in the `openagentontology` package (Apache-2.0), imported lazily via `find_spec`, so **no required dependency is added** — absent it, the module returns an explicit unsigned stub, and a broken install is surfaced rather than silently degrading.

## Verified

5 tests. With the package installed the receipt signs (Ed25519 + post-quantum legs ML-DSA-65 + SLH-DSA), verifies offline, and flipping the `scraped` flag after signing breaks verification.
