### PR TITLE
security: source Django secret key from env

### DIFF
--- a/openoutreach/settings.py
+++ b/openoutreach/settings.py
@@ -6,6 +6,8 @@ import os
 import sys
 from pathlib import Path
 
+from django.core.management.utils import get_random_secret_key
+
 # The agents drive async pydantic-ai from a sync boundary (core/llm.py), so an
 # event loop can be live on the thread when the ORM is touched. We only use the
 # ORM synchronously, so Django's async-safety guard is safe to relax.
@@ -15,7 +17,7 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 
 BASE_DIR = ROOT_DIR
 
-SECRET_KEY = "openoutreach-local-dev-key-change-in-production"
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY") or get_random_secret_key()
 
 DEBUG = True
 

--- a/tests/test_settings_security.py
+++ b/tests/test_settings_security.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SETTINGS_PY = Path(__file__).resolve().parent.parent / "openoutreach" / "settings.py"
+
+
+def _load_settings(module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, SETTINGS_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_settings_use_deployment_secret_when_provided(monkeypatch):
+    monkeypatch.setenv("DJANGO_SECRET_KEY", "deployment-secret")
+
+    settings = _load_settings("settings_with_env_secret")
+
+    assert settings.SECRET_KEY == "deployment-secret"
+
+
+def test_settings_generate_nondefault_secret_when_env_missing(monkeypatch):
+    monkeypatch.delenv("DJANGO_SECRET_KEY", raising=False)
+
+    settings_a = _load_settings("settings_without_env_secret_a")
+    settings_b = _load_settings("settings_without_env_secret_b")
+
+    assert settings_a.SECRET_KEY != "openoutreach-local-dev-key-change-in-production"
+    assert settings_b.SECRET_KEY != "openoutreach-local-dev-key-change-in-production"
+    assert settings_a.SECRET_KEY != settings_b.SECRET_KEY


### PR DESCRIPTION
## Summary
This removes the hardcoded Django `SECRET_KEY` from source control and makes deployments supply it through `DJANGO_SECRET_KEY`.

## Security impact
Before this change, every deployment that used the checked-in settings file shared a known signing key. Anyone who learned that value could forge Django-signed data such as session cookies and reset tokens.

## Changes
- load `SECRET_KEY` from `DJANGO_SECRET_KEY` when provided
- fall back to a fresh random key when the environment variable is absent so the repo no longer contains a reusable signing secret
- add regression coverage for both the env-backed and fallback paths

## Validation
- `PYTHONPATH=/tmp/openoutreach-secret-pr /tmp/openoutreach-venv/bin/pytest -q tests/test_settings_security.py`
