### PR TITLE
security: verify TLS certificates on mail transport

### DIFF
--- a/openoutreach/emails/sender.py
+++ b/openoutreach/emails/sender.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import smtplib
+import ssl
 from email.message import EmailMessage
 from email.utils import make_msgid
 
@@ -283,7 +284,7 @@ def _deliver(mailbox, email_message: EmailMessage, row) -> None:
 
     try:
         with _SMTP(mailbox.host, mailbox.port, timeout=SMTP_TIMEOUT_SECONDS) as smtp:
-            smtp.starttls()
+            smtp.starttls(context=ssl.create_default_context())
             smtp.login(mailbox.username, mailbox.password)
             smtp.send_message(email_message)
             record_acceptance(row, *smtp.accepted_response)

--- a/openoutreach/emails/sync.py
+++ b/openoutreach/emails/sync.py
@@ -45,6 +45,7 @@ arrived" stay different statements.
 from __future__ import annotations
 
 import logging
+import ssl
 
 from django.utils import timezone
 from imapclient import IMAPClient
@@ -233,8 +234,13 @@ def _record_coverage(coverage: FolderCoverage, uidvalidity: int, *, complete: bo
 
 def _connect(mailbox) -> IMAPClient:
     """A logged-in IMAP session for *mailbox*, as a context manager."""
-    client = IMAPClient(mailbox.imap_host, port=mailbox.imap_port, ssl=True,
-                        timeout=IMAP_TIMEOUT_SECONDS)
+    client = IMAPClient(
+        mailbox.imap_host,
+        port=mailbox.imap_port,
+        ssl=True,
+        ssl_context=ssl.create_default_context(),
+        timeout=IMAP_TIMEOUT_SECONDS,
+    )
     client.login(mailbox.username, mailbox.password)
     return client
 

--- a/openoutreach/emails/warmth.py
+++ b/openoutreach/emails/warmth.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import email
 import imaplib
 import logging
+import ssl
 from collections import Counter
 from datetime import datetime, timedelta
 from email.utils import parsedate_to_datetime
@@ -174,8 +175,12 @@ def read_sent_history(mailbox) -> Counter:
     """``{local date: messages sent}`` over the trailing window, from the box's
     Sent folder. Headers only — no bodies are fetched, and the folder is opened
     read-only."""
-    imap = imaplib.IMAP4_SSL(mailbox.imap_host, mailbox.imap_port,
-                             timeout=IMAP_TIMEOUT_SECONDS)
+    imap = imaplib.IMAP4_SSL(
+        mailbox.imap_host,
+        mailbox.imap_port,
+        timeout=IMAP_TIMEOUT_SECONDS,
+        ssl_context=ssl.create_default_context(),
+    )
     try:
         imap.login(mailbox.username, mailbox.password)
         folder = _sent_folder(imap)

--- a/tests/emails/test_tls_verification.py
+++ b/tests/emails/test_tls_verification.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections import Counter
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from openoutreach.emails.sender import _deliver
+from openoutreach.emails.sync import _connect
+from openoutreach.emails.warmth import read_sent_history
+
+
+class _FakeSmtp:
+    def __init__(self):
+        self.starttls_calls = []
+        self.accepted_response = (250, b"queued")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def starttls(self, **kwargs):
+        self.starttls_calls.append(kwargs)
+
+    def login(self, username, password):
+        return None
+
+    def send_message(self, message):
+        return None
+
+
+class _FakeImap:
+    def login(self, username, password):
+        return None
+
+
+def _mailbox():
+    return SimpleNamespace(
+        host="smtp.example.com",
+        port=587,
+        imap_host="imap.example.com",
+        imap_port=993,
+        username="user@example.com",
+        password="pw",
+        from_address="user@example.com",
+    )
+
+
+def test_deliver_uses_verified_starttls_context():
+    smtp = _FakeSmtp()
+
+    with patch("openoutreach.emails.sender._SMTP", return_value=smtp), \
+         patch("openoutreach.emails.delivery_policy.record_acceptance"), \
+         patch("openoutreach.emails.delivery_policy.record_failure"):
+        _deliver(_mailbox(), SimpleNamespace(), SimpleNamespace())
+
+    assert len(smtp.starttls_calls) == 1
+    context = smtp.starttls_calls[0]["context"]
+    assert context.verify_mode.name == "CERT_REQUIRED"
+    assert context.check_hostname is True
+
+
+def test_connect_uses_verified_imap_context():
+    mailbox = _mailbox()
+    imap = _FakeImap()
+
+    with patch("openoutreach.emails.sync.IMAPClient", return_value=imap) as client_cls:
+        _connect(mailbox)
+
+    context = client_cls.call_args.kwargs["ssl_context"]
+    assert context.verify_mode.name == "CERT_REQUIRED"
+    assert context.check_hostname is True
+
+
+def test_read_sent_history_uses_verified_imap_context():
+    mailbox = _mailbox()
+    imap = _FakeImap()
+
+    with patch("openoutreach.emails.warmth.imaplib.IMAP4_SSL", return_value=imap) as imap_ssl, \
+         patch("openoutreach.emails.warmth._sent_folder", return_value="Sent"), \
+         patch("openoutreach.emails.warmth._count_by_day", return_value=Counter()), \
+         patch("openoutreach.emails.warmth._logout"):
+        read_sent_history(mailbox)
+
+    context = imap_ssl.call_args.kwargs["ssl_context"]
+    assert context.verify_mode.name == "CERT_REQUIRED"
+    assert context.check_hostname is True


### PR DESCRIPTION
## Summary
This hardens OpenOutreach mail transport so outbound SMTP STARTTLS and both IMAP read paths verify the server certificate against the system trust store.

## Security impact
Before this change, outbound SMTP upgraded with `starttls()` and IMAP connections were created without an explicit verified TLS context. That allowed a machine-in-the-middle presenting a forged or self-signed certificate to intercept mailbox credentials and mail content.

## Changes
- pass `ssl.create_default_context()` to SMTP STARTTLS in `openoutreach/emails/sender.py`
- pass `ssl.create_default_context()` to inbound IMAP sync in `openoutreach/emails/sync.py`
- pass `ssl.create_default_context()` to Sent-folder IMAP reads in `openoutreach/emails/warmth.py`
- add targeted regression coverage for all three call sites

## Validation
- `PYTHONPATH=/tmp/openoutreach-tls-pr /tmp/openoutreach-venv/bin/pytest -q tests/emails/test_tls_verification.py`
