### PR TITLE
security: require STARTTLS before SMTP auth

### DIFF
--- a/openoutreach/emails/smtp.py
+++ b/openoutreach/emails/smtp.py
@@ -5,8 +5,7 @@ No test send — boxes are mid-warmup; we only confirm the credentials log in.
 The transport is chosen by port so real providers all pass the gate:
 
   * 465        → implicit TLS (``SMTP_SSL``) — Google, Fastmail, most hosts
-  * 587 / 25   → plaintext connect, then ``STARTTLS`` *if the server advertises
-                 it* (it always does on 587), else stay plaintext (rare relays)
+  * 587 / 25   → plaintext connect, then upgrade with ``STARTTLS`` before auth
 
 Hard-coding ``starttls()`` was the old bug: a 465-only box could never connect,
 so onboarding rejected working credentials and re-asked the mailbox forever.
@@ -32,9 +31,10 @@ def verify_auth(host: str, port: int, username: str, password: str) -> tuple[boo
         else:
             with smtplib.SMTP(host, port, timeout=20) as smtp:
                 smtp.ehlo()
-                if smtp.has_extn("starttls"):
-                    smtp.starttls(context=context)
-                    smtp.ehlo()
+                if not smtp.has_extn("starttls"):
+                    return False, "connection failed: server does not advertise STARTTLS"
+                smtp.starttls(context=context)
+                smtp.ehlo()
                 smtp.login(username, password)
         return True, "ok"
     except smtplib.SMTPAuthenticationError as e:

--- a/tests/emails/test_smtp.py
+++ b/tests/emails/test_smtp.py
@@ -34,6 +34,7 @@ def test_auth_ok_implicit_ssl_on_465():
 def test_login_password_rejection_surfaces_app_password_hint():
     error = smtplib.SMTPAuthenticationError(534, b"application-specific password required")
     with patch("smtplib.SMTP") as smtp_cls:
+        smtp_cls.return_value.__enter__.return_value.has_extn.return_value = True
         smtp_cls.return_value.__enter__.return_value.login.side_effect = error
         ok, message = verify_auth("smtp.gmail.com", 587, "u", "p")
     assert not ok and "app password" in message and "534" in message
@@ -43,3 +44,13 @@ def test_connection_failure_is_reported_not_raised():
     with patch("smtplib.SMTP", side_effect=OSError("no route to host")):
         ok, message = verify_auth("smtp.gmail.com", 587, "u", "p")
     assert not ok and "connection failed" in message
+
+
+def test_auth_rejects_plaintext_downgrade_when_starttls_missing():
+    with patch("smtplib.SMTP") as smtp_cls:
+        conn = smtp_cls.return_value.__enter__.return_value
+        conn.has_extn.return_value = False
+        ok, message = verify_auth("smtp.example.com", 587, "u", "p")
+    assert not ok
+    assert "STARTTLS" in message
+    conn.login.assert_not_called()


### PR DESCRIPTION
## Summary
Require `STARTTLS` before authenticating over SMTP on the opportunistic-TLS ports.

## Security impact
Before this change, mailbox onboarding connected in plaintext on ports like 587 or 25 whenever the server failed to advertise `STARTTLS`. That let a machine-in-the-middle strip the upgrade and capture the mailbox password during the onboarding auth check.

## Changes
- fail closed when a non-SSL SMTP server does not advertise `STARTTLS`
- keep implicit TLS on port 465 unchanged
- add a regression test that proves login is never attempted after a STARTTLS downgrade

## Validation
- source-level regression check confirmed `verify_auth()` now returns failure when `STARTTLS` is missing and never calls `login()` on that path
- source-level regression check confirmed the normal 587 path still upgrades with `starttls()` before authentication
- full pytest execution was not possible in this environment because the repo's test dependencies are not installed in the available host Python runtime

## Disclosure notes
- finding id: FS-007
- pool: security-impact
- GitHub private vulnerability reporting is disabled for this repo
- nothing else was submitted for this issue before this PR
