### PR TITLE
security: keep freemium selection scoped to freemium leads

### DIFF
--- a/openoutreach/core/pipeline/freemium_pool.py
+++ b/openoutreach/core/pipeline/freemium_pool.py
@@ -24,8 +24,12 @@ def find_freemium_candidate(campaign, qualifier) -> dict | None:
     from openoutreach.crm.models import Deal, Lead
 
 
-    # All embedded lead IDs
-    embedded_pks = set(Lead.objects.filter(embedding__isnull=False).values_list("pk", flat=True))
+    # Freemium may only rank leads already attached to this freemium campaign.
+    embedded_pks = set(
+        Lead.objects.filter(embedding__isnull=False, deal__campaign=campaign)
+        .values_list("pk", flat=True)
+        .distinct()
+    )
 
     # Seed profiles: QUALIFIED Deals in this campaign
     seed_pks = set(

--- a/tests/test_freemium_pool.py
+++ b/tests/test_freemium_pool.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from openoutreach.core.models import Campaign
+from openoutreach.core.pipeline.freemium_pool import find_freemium_candidate
+from openoutreach.crm.models import Deal, DealState, Lead
+
+
+class DummyQualifier:
+    def rank_profiles(self, profiles):
+        return sorted(profiles, key=lambda profile: profile["lead_id"])
+
+
+def _embedded_lead(profile_url: str) -> Lead:
+    lead = Lead.objects.create(profile_url=profile_url)
+    lead.embedding_array = np.ones(384, dtype=np.float32)
+    lead.save(update_fields=["embedding"])
+    return lead
+
+
+def test_freemium_pool_never_selects_operator_owned_leads(db, campaign):
+    freemium = Campaign.objects.create(name="Freemium", is_freemium=True)
+
+    freemium_seed = _embedded_lead("https://example.com/freemium-seed")
+    operator_only = _embedded_lead("https://example.com/operator-owned")
+
+    Deal.objects.create(
+        campaign=freemium,
+        lead=freemium_seed,
+        state=DealState.QUALIFIED,
+    )
+    Deal.objects.create(
+        campaign=campaign,
+        lead=operator_only,
+        state=DealState.QUALIFIED,
+    )
+
+    candidate = find_freemium_candidate(freemium, DummyQualifier())
+
+    assert candidate == {
+        "lead_id": freemium_seed.pk,
+        "profile_url": freemium_seed.profile_url,
+    }


### PR DESCRIPTION
## Summary
This keeps the freemium candidate pool scoped to leads already attached to the freemium campaign.

## Security impact
Before this change, `find_freemium_candidate()` ranked every embedded lead in the database once freemium seed leads were exhausted. That let the built-in freemium campaign pick operator-owned prospects from unrelated campaigns and send OpenOutreach promotional email to them from the operator's mailbox.

## Changes
- restrict the embedded-lead pool to leads that already have a deal in the current freemium campaign
- add a regression test proving an operator-owned lead in another campaign is not returned to freemium

## Validation
- logic verified by inspection against `openoutreach/core/pipeline/freemium_pool.py`
- included focused regression test in `tests/test_freemium_pool.py`
- full pytest execution was not possible in this environment because the available virtualenv is missing test dependencies (`pytest`, `numpy`)

## Disclosure notes
- finding id: FS-009
- pool: security-impact
- GitHub private vulnerability reporting is disabled for this repo
- nothing has been submitted publicly for this finding before this PR
