### PR TITLE
hardening: keep local secrets out of Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@
 .idea
 __pycache__
 .vscode
+.env
+data/
+media/


### PR DESCRIPTION
## Summary
This keeps local secrets and runtime state out of Docker build context and image layers.

## Security impact
Before this change, `.dockerignore` excluded only source-control and editor artifacts. Common local secrets and runtime state such as `.env`, `data/`, and `media/` were still eligible to be copied into a Docker build context and baked into image layers by broad `COPY . .` patterns or cached by remote builders.

## Changes
- ignore `.env`
- ignore `data/`
- ignore `media/`

## Validation
- verified the updated `.dockerignore` now excludes the obvious secret/runtime paths present in this repo layout
- no automated test applies to `.dockerignore` changes

## Disclosure notes
- finding id: FS-010
- pool: hardening
- GitHub private vulnerability reporting is disabled for this repo
- nothing has been submitted publicly for this finding before this PR
